### PR TITLE
Update detect_stem.R

### DIFF
--- a/R/detect_stem.R
+++ b/R/detect_stem.R
@@ -223,6 +223,12 @@ detect_stem <- function(
       dplyr::mutate(dplyr::across(dplyr::any_of(available_cols), as.integer))
   }
 
+  # Convert logical 'Stem' attribute to numeric
+  stem_points_class@data$Stem <- as.numeric(stem_points_class@data$Stem)
+
+  # Add the 'Stem' attribute to the LAS header
+  stem_points_class <- add_lasattribute(stem_points_class, name = "Stem", desc = "Stem_points")
+
   # Return the filtered stem points.
   return(stem_points_class)
 }


### PR DESCRIPTION
Updated the detect_stem.R function so that Stem attribute is converted to a numeric binary and saved as an official LasAttribute, so that it can be written to point clouds. This should be useful if people want to write outputs from detect_stem.R and then read and run stem_diameter_profile() on the results, adding a layer of redundancy. Also good for checking stem delineations in CloudCompare etc.

Cheers,
RJLH